### PR TITLE
Add compatibility with zsh

### DIFF
--- a/complete
+++ b/complete
@@ -7,19 +7,20 @@ function _bash_cli() {
 
     local curr_arg;
     curr_arg="${COMP_WORDS[COMP_CWORD]}"
+    prev_arg="${COMP_WORDS[COMP_CWORD-1]}"
 
     # Locate the correct command to execute by looking through the app directory
     # for folders and files which match the arguments provided on the command line.
     local cmd_file="$root_dir/app/"
     local cmd_arg_start=1
+
+    # If current or previous argument is "help", don't suggest anyting
+    if [[ "$curr_arg" == "help" || "$prev_arg" == "help" ]]; then
+        COMPREPLY=()
+        return
+    fi
+
     while [[ -d "$cmd_file" && $cmd_arg_start -le $COMP_CWORD ]]; do
-
-        # Handle the help virtual command by "ignoring" it
-        if [[ "${COMP_WORDS[cmd_arg_start]}" == "help" ]]; then
-            cmd_arg_start=$(($cmd_arg_start+1))
-            continue
-        fi
-
         cmd_file="$cmd_file/${COMP_WORDS[cmd_arg_start]}"
         cmd_arg_start=$(($cmd_arg_start+1))
     done

--- a/complete
+++ b/complete
@@ -47,10 +47,12 @@ function _bash_cli() {
     # available within it, as well as the `help` virtual command.
     elif [ -d "$cmd_file" ]; then
         local opts=("help")
-        while IFS= read -d $'\0' -r file ; do
+        local file_list=(`find $cmd_file/ -maxdepth 1 ! -path $cmd_file/ ! -iname '*.*' -print`)
+
+        for file in "${file_list[@]}"; do
             opts=("${opts[@]}" `basename $file`)
-        done < <(find $cmd_file/ -maxdepth 1 ! -path $cmd_file/ ! -iname '*.*' -print0)
-        
+        done
+
         IFS="
         "
         COMPREPLY=(`compgen -W "$(printf '%s\n' "${opts[@]}")" -- "$curr_arg"`)

--- a/framework/complete
+++ b/framework/complete
@@ -49,10 +49,12 @@ function {{ function_name }}() {
     # available within it, as well as the `help` virtual command.
     elif [ -d "$cmd_file" ]; then
         local opts=("help")
-        while IFS= read -d $'\0' -r file ; do
+        local file_list=(`find $cmd_file/ -maxdepth 1 ! -path $cmd_file/ ! -iname '*.*' -print`)
+
+        for file in "${file_list[@]}"; do
             opts=("${opts[@]}" `basename $file`)
-        done < <(find $cmd_file/ -maxdepth 1 ! -path $cmd_file/ ! -iname '*.*' -print0)
-        
+        done
+
         IFS="
         "
         COMPREPLY=(`compgen -W "$(printf '%s\n' "${opts[@]}")" -- "$curr_arg"`)

--- a/framework/complete
+++ b/framework/complete
@@ -9,19 +9,20 @@ function {{ function_name }}() {
 
     local curr_arg;
     curr_arg="${COMP_WORDS[COMP_CWORD]}"
+    prev_arg="${COMP_WORDS[COMP_CWORD-1]}"
 
     # Locate the correct command to execute by looking through the app directory
     # for folders and files which match the arguments provided on the command line.
     local cmd_file="$root_dir/app/"
     local cmd_arg_start=1
+
+    # If current or previous argument is "help", don't suggest anyting
+    if [[ "$curr_arg" == "help" || "$prev_arg" == "help" ]]; then
+        COMPREPLY=()
+        return
+    fi
+
     while [[ -d "$cmd_file" && $cmd_arg_start -le $COMP_CWORD ]]; do
-
-        # Handle the help virtual command by "ignoring" it
-        if [[ "${COMP_WORDS[cmd_arg_start]}" == "help" ]]; then
-            cmd_arg_start=$(($cmd_arg_start+1))
-            continue
-        fi
-
         cmd_file="$cmd_file/${COMP_WORDS[cmd_arg_start]}"
         cmd_arg_start=$(($cmd_arg_start+1))
     done


### PR DESCRIPTION
The bash `read` command previously used in `complete` and `framework/complete` is a bash built-in command which has different implementation with zsh's `read`. This PR changes the logic to use array instead to maintain compatibility between bash and zsh.

Also, this PR fixes the possibility of infinitely chaining `help` virtual command. This will happen when one of the subcommands is `help`. You can try with `bcl help`, press tab, and chose `help` again, ad infinitum. e.g.:
```
$ ./pkictl help help etcd help [TAB]
deploy  help   <-- suggestions
```