### PR TITLE
Cache downloaded packages to be used in subsequent installs

### DIFF
--- a/app/.helper/package
+++ b/app/.helper/package
@@ -7,6 +7,7 @@ source $ROOT_DIR/app/.helper/system
 LATEST_VERSION="latest"
 DEFAULT_CHANNEL="release"
 DEFAULT_PLATFORM="$(platform)"
+CACHE_DIRECTORY="${HOME}/.bcl/.cache"
 
 # get_package_canonical_name formats package name, version, channel, and
 # optionally target platform into a canonical name
@@ -82,10 +83,19 @@ get_package_platform() {
     echo "$1" | sed $sed_opts 's/^[a-zA-Z0-9]+-[a-zA-Z0-9.]+-[a-zA-Z0-9]+-?(.*)$/\1/p'
 }
 
-# get_available_packages list available packages in a bcl release git repository
+# get_available_packages list available packages in a bcl release git
+# repository. Accepts the output of `git ls-remote` as an input.
 get_available_packages() {
-    remotes=$(git ls-remote "$1")
-    echo "$remotes" | _grep -Poe 'refs/heads/.*$' | sed 's#refs/heads/##'
+    echo "$1" | _grep -Poe 'refs/heads/.*$' | sed 's#refs/heads/##'
+}
+
+# get_package_commit_hash returns the commit has of a package release. Accepts
+# the output of `git ls-remote` and the package canonical name as the inputs.
+get_package_commit_hash() {
+    local git_ls_remote="$1"
+    local package_canonical_name="$2"
+
+    echo "$git_ls_remote" | _grep -e "$package_canonical_name" | grep -Poe '^[0-9a-fA-F]+'
 }
 
 # get_available_canonical_name returns the canonical name of available package
@@ -94,7 +104,7 @@ get_available_canonical_name() {
     # The output of get_available_packages(). Accepted as a parameter so we
     # don't need to call git ls-remote multiple times when installing multiple
     # packages.
-    git_ls_remote_output="$1"
+    packages_available="$1"
 
     package_name=$2
     package_version=$3
@@ -113,7 +123,7 @@ get_available_canonical_name() {
         package_platform=$DEFAULT_PLATFORM
     fi
 
-    branches="$(echo "$git_ls_remote_output" |  _grep -Pe "^$package_name-" || true | sort -V)"
+    branches="$(echo "$packages_available" |  _grep -Pe "^$package_name-" || true | sort -V)"
 
     if [ "$package_version" == "$LATEST_VERSION" ]; then
         branches="$(echo "$branches" | _grep -Pe "^$package_name-" | _grep -Pe "-$package_channel\$" || true)"
@@ -173,10 +183,11 @@ is_package_installed() {
 # install_package installs a package. Returns "true" if the package was
 # installed (i.e. it was not present before or was outdated).
 install_package() {
-    release_repo=$1
-    package_canonical_name=$2
-    install_dir=$3
-    install_mode=$4
+    local release_repo=$1
+    local package_canonical_name=$2
+    local package_commit_hash=$3
+    local install_dir=$4
+    local install_mode=$5
 
     if [[ -z "$install_mode" ]]; then
         install_mode="default"
@@ -190,16 +201,60 @@ install_package() {
         return
     fi
 
+    # Cache the package
+    cache_package "$release_repo" "$package_canonical_name" "$package_commit_hash" "$install_mode"
+
+    # Copy the cached package
+    local pkg_cache_dir="$CACHE_DIRECTORY/$package_canonical_name-$package_commit_hash"
+
     mkdir -p "$install_dir/cli"
-
-    clone_dir="/tmp/.bcl-$package_canonical_name"
-
-    rm -rf "$clone_dir"
-    git clone -b "$package_canonical_name" "$release_repo" --depth 1 "$clone_dir"
-
     rm -rf "$install_dir/cli/$package_name"
-    cp -R  "$clone_dir"/* "$install_dir/cli"
-    rm -rf "$clone_dir"
+    cp -R  "$pkg_cache_dir"/* "$install_dir/cli"
 
     echo "true"
+}
+
+# cache_package caches a package to $CACHE_DIRECTORY, skipping if the package
+# is already cached.
+#
+# Args:
+#   release_repo: Git repository address to clone from
+#
+#   package_canonical_name: Canonical name of the package to be cached, is also
+#       the branch name in release_repo
+#
+#   package_commit_hash: Commit has of the package_canonical_name branch
+#
+#   cache_mode: Set to "force" to redownload the package. (Optional), defaults
+#       to "default".
+cache_package() {
+    local release_repo=$1
+    local package_canonical_name=$2
+    local package_commit_hash=$3
+    local cache_mode=$4
+
+    if [[ -z "$cache_mode" ]]; then
+        cache_mode="default"
+    fi
+
+    local pkg_cache_dir="$CACHE_DIRECTORY/$package_canonical_name-$package_commit_hash"
+
+    if [[ -d "$pkg_cache_dir" ]] && [ "$cache_mode" != "force" ]; then
+        return
+    fi
+
+    # "Install" the package into the cache directory
+    mkdir -p "$CACHE_DIRECTORY"
+
+    rm -rf "$pkg_cache_dir"
+    mkdir -p "$pkg_cache_dir"
+
+    git clone -b "$package_canonical_name" "$release_repo" --depth 1 "$pkg_cache_dir"
+    rm -rf "$pkg_cache_dir/.git"
+}
+
+# clear_package_cache removes the package cache directory
+clear_package_cache() {
+    echo "Emptying package cache directory $CACHE_DIRECTORY..."
+    rm -rf "$CACHE_DIRECTORY"
 }

--- a/app/.helper/package
+++ b/app/.helper/package
@@ -86,7 +86,9 @@ get_package_platform() {
 # get_available_packages list available packages in a bcl release git
 # repository. Accepts the output of `git ls-remote` as an input.
 get_available_packages() {
-    echo "$1" | _grep -Poe 'refs/heads/.*$' | sed 's#refs/heads/##'
+    local git_ls_remote="$1"
+
+    echo "$git_ls_remote" | _grep -Poe 'refs/heads/.*$' | sed 's#refs/heads/##'
 }
 
 # get_package_commit_hash returns the commit has of a package release. Accepts
@@ -189,7 +191,7 @@ install_package() {
     local install_dir=$4
     local install_mode=$5
 
-    if [[ -z "$install_mode" ]]; then
+    if [[ "$install_mode" != "default" ]] && [[ "$install_mode" != "force" ]]; then
         install_mode="default"
     fi
 
@@ -233,8 +235,8 @@ cache_package() {
     local package_commit_hash=$3
     local cache_mode=$4
 
-    if [[ -z "$cache_mode" ]]; then
-        cache_mode="default"
+    if [[ "$install_mode" != "default" ]] && [[ "$install_mode" != "force" ]]; then
+        install_mode="default"
     fi
 
     local pkg_cache_dir="$CACHE_DIRECTORY/$package_canonical_name-$package_commit_hash"

--- a/app/package/cache-clear
+++ b/app/package/cache-clear
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $ROOT_DIR/app/.helper/package
+
+clear_package_cache

--- a/app/package/cache-clear.help
+++ b/app/package/cache-clear.help
@@ -1,0 +1,1 @@
+Clear package cache directory

--- a/app/package/global-install
+++ b/app/package/global-install
@@ -31,11 +31,15 @@ main() {
 
     # Fetch appropriate version of the package from git
     echo "Fetching available versions of $package_name..."
-    package_canonical_name="$(get_available_canonical_name "$(get_available_packages "$REPOSITORY")" "$package_name" "$package_version" "$package_channel" "$package_platform")"
+    remote_branches=$(git ls-remote "$REPOSITORY")
+    available_packages="$(get_available_packages "$remote_branches")"
+
+    package_canonical_name="$(get_available_canonical_name "$available_packages" "$package_name" "$package_version" "$package_channel" "$package_platform")"
+    package_commit_hash="$(get_package_commit_hash "$remote_branches" "$package_canonical_name")"
 
     # Install the package
     echo "Installing $package_canonical_name..."
-    is_installed=$(install_package "$REPOSITORY" "$package_canonical_name" "$INSTALL_DIRECTORY")
+    is_installed=$(install_package "$REPOSITORY" "$package_canonical_name" "$package_commit_hash" "$INSTALL_DIRECTORY")
 
     if [[ "$is_installed" == "true" ]]; then
         echo "Finished installing $package_canonical_name"

--- a/app/package/install
+++ b/app/package/install
@@ -19,7 +19,8 @@ fi
 
 # Fetch appropriate version of the package from git
 echo "Fetching available packages from git..."
-available_packages="$(get_available_packages "$RELEASE_REPOSITORY")"
+remote_branches=$(git ls-remote "$RELEASE_REPOSITORY")
+available_packages="$(get_available_packages "$remote_branches")"
 
 for PACKAGE_BUILD in `tail -n+2 $APP_DIR/BCLFile`; do
     if [[ -d .$PACKAGE_BUILD ]]; then
@@ -32,8 +33,9 @@ for PACKAGE_BUILD in `tail -n+2 $APP_DIR/BCLFile`; do
     package_platform=$(get_package_platform $PACKAGE_BUILD)
 
     package_canonical_name="$(get_available_canonical_name "$available_packages" "$package_name" "$package_version" "$package_channel" "$package_platform")"
+    package_commit_hash="$(get_package_commit_hash "$remote_branches" "$package_canonical_name")"
 
-    is_installed=$(install_package "$RELEASE_REPOSITORY" "$package_canonical_name" "$APP_DIR")
+    is_installed=$(install_package "$RELEASE_REPOSITORY" "$package_canonical_name" "$package_commit_hash" "$APP_DIR")
     if [[ "$is_installed" == "true" ]]; then
         echo "$package_canonical_name installed"
     else


### PR DESCRIPTION
Packages cloned from git will be cached to `~/.bcl/.cache/<branch_name>-<branch_commit_hash>/` and will be used on subsequent installs. The cache can be cleared with `bcl package cache-clear`.