### PR TITLE
Fix wrong grep invocation causing crash in MacOS

### DIFF
--- a/app/.helper/package
+++ b/app/.helper/package
@@ -97,7 +97,7 @@ get_package_commit_hash() {
     local git_ls_remote="$1"
     local package_canonical_name="$2"
 
-    echo "$git_ls_remote" | _grep -e "$package_canonical_name" | grep -Poe '^[0-9a-fA-F]+'
+    echo "$git_ls_remote" | _grep -e "$package_canonical_name" | _grep -Poe '^[0-9a-fA-F]+'
 }
 
 # get_available_canonical_name returns the canonical name of available package


### PR DESCRIPTION
`grep` (rather than `_grep`) was directy invoked in #6, causing bcl to crash on MacOS