### PR TITLE
Fix installing package with wrong platform when latest version was requested

### DIFF
--- a/app/.helper/package
+++ b/app/.helper/package
@@ -128,7 +128,7 @@ get_available_canonical_name() {
     branches="$(echo "$packages_available" |  _grep -Pe "^$package_name-" || true | sort -V)"
 
     if [ "$package_version" == "$LATEST_VERSION" ]; then
-        branches="$(echo "$branches" | _grep -Pe "^$package_name-" | _grep -Pe "-$package_channel\$" || true)"
+        branches="$(echo "$branches" | _grep -Pe "^$package_name-" | _grep -Pe "-$package_channel" || true)"
     else
         # If a version number is specified, filter by it too
         branches="$(echo "$branches" | _grep -Pe "^$package_name-v$package_version-$package_channel" || true)"


### PR DESCRIPTION
This PR fixes an error where a package was installed with the wrong platform than the machine's platform when the requested package version is "latest" (e.g. when executing `bcl package global-install some_package`).