### PR TITLE
fix: Allow dots in package channel

### DIFF
--- a/app/.helper/package
+++ b/app/.helper/package
@@ -80,7 +80,7 @@ get_package_platform() {
 
     # Unlike package name and channel, platform can contain dashes, and thus
     # cannot be splitted with awk.
-    echo "$1" | sed $sed_opts 's/^[a-zA-Z0-9]+-[a-zA-Z0-9.]+-[a-zA-Z0-9]+-?(.*)$/\1/p'
+    echo "$1" | sed $sed_opts 's/^[a-zA-Z0-9]+-[a-zA-Z0-9.]+-[a-zA-Z0-9.]+-?(.*)$/\1/p'
 }
 
 # get_available_packages list available packages in a bcl release git


### PR DESCRIPTION
Fix regex used in `get_package_platform()` to allow package channel to contain dots (`.`). Dots can be used if the package's channel is also a semver pre-release segment. E.g. in `mypackage-v1.0.0-beta.1-linux-x86_64`, `beta.1` is the package's channel.
